### PR TITLE
Feat | ImageManager 구현

### DIFF
--- a/Assets/02. Scripts/02-01. Common/Addressable/ImageManager.cs
+++ b/Assets/02. Scripts/02-01. Common/Addressable/ImageManager.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading.Tasks;
+using UnityEngine;
+using UnityEngine.UI;
+
+public class ImageManager : MonoBehaviourSingleton<ImageManager>
+{
+    private Dictionary<Type, string> _prefixDict = new();
+    private Dictionary<Type, Dictionary<int, Sprite>> _imageDict = new();
+
+    protected override void Awake()
+    {
+        base.Awake();
+    }
+
+    private void Start()
+    {
+        Global.Instance.OnDataLoaded += InitImageManager;
+    }
+
+    private async void InitImageManager()
+    {
+        InitPrefixDict();
+        await InitImageDict<IngredientData>(DataTable.Instance.GetIngredientDataList());
+        await InitImageDict<PotionData>(DataTable.Instance.GetPotionDataList());
+        await InitImageDict<ProductData>(DataTable.Instance.GetProductDataList());
+    }
+
+    private void InitPrefixDict()
+    {
+        _prefixDict[typeof(IngredientData)] = "Image_Ingredient_";
+        _prefixDict[typeof(PotionData)] = "Image_Potion_";
+        _prefixDict[typeof(ProductData)] = "Image_Product_";
+    }
+
+    private async Task InitImageDict<T>(ReadOnlyList<T> dataList)
+    {
+        var type = typeof(T);
+        if (!_prefixDict.TryGetValue(type, out string prefix))
+        {
+            Debug.LogError($"{type.Name} 타입은 이미지 매니저에서 캐싱을 통해 관리하는 대상이 아닙니다.");
+            return;
+        }
+
+        var tidField = type.GetField("TID");
+        if (tidField == null || tidField.FieldType != typeof(int))
+        {
+            Debug.LogError($"{type.Name} 타입은 TID를 가지고 있지 않습니다.");
+            return;
+        }
+
+        Dictionary<int, Sprite> dict = new();
+        foreach (var item in dataList)
+        {
+            var result = await LoadImageForItem(item, prefix, tidField);
+            if (result.HasValue)
+                dict[result.Value.tid] = result.Value.sprite;
+        }
+        _imageDict[type] = dict;
+    }
+
+    private async Task<(int tid, Sprite sprite)?> LoadImageForItem<T>(T item, string prefix, FieldInfo tidField)
+    {
+        int tid = (int)tidField.GetValue(item);
+        string addressableKey = prefix + tid;
+
+        Sprite sprite = await AssetManager.Instance.LoadAsset<Sprite>(addressableKey);
+        if (sprite == null)
+        {
+            Debug.LogWarning($"{addressableKey} 주소를 가진 이미지가 Addressable에 존재하지 않습니다.");
+            return null;
+        }
+        return (tid, sprite);
+    }
+
+    public Sprite GetImage(Type type, int id)
+    {
+        if (_imageDict.TryGetValue(type, out var dict) && dict.TryGetValue(id, out var sprite))
+        {
+            return sprite;
+        }
+
+        Debug.LogWarning($"{type.Name} 타입의 {id} TID를 가진 이미지 리소스가 존재하지 않습니다. " +
+            $"어드레서블 그룹을 다시한번 확인해주세요");
+        return null;
+    }
+
+    public Sprite GetImage<T>(int id)
+    {
+        var type = typeof(T);
+        return GetImage(type, id);
+    }
+}

--- a/Assets/02. Scripts/02-01. Common/Addressable/ImageManager.cs.meta
+++ b/Assets/02. Scripts/02-01. Common/Addressable/ImageManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6d18bc3c7155d9748964b0c22cacaa46


### PR DESCRIPTION
### ※ PR 작성 전 체크리스트 ※
1. 작업하신 브랜치가 최신화되었나요? (behind 커밋이 존재하지 않나요?) ㅔㅔ
2. 추가하신 기능 및 전체 로직이 정상적으로 동작하는 것을 확인하셨나요? (기능 테스트를 완료하셨나요?) ㅔㅔ
3. Assignee에 본인 계정을 추가하고, labels에 본인 이름 label과 PR의 작업내용을 잘 나타낼 수 있는 라벨을 추가하셨나요? ㅔㅔ
<br/>

### 📝작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.(이미지 첨부 가능)

### 1. ImageManager 구현
- 인게임에서 사용할 이미지 리소스들을 에셋매니저에서 한꺼번에 로드해와 캐싱해놓는 ImageManager를 구현했습니다.
- 가져올 수 있는 Image 종류는 3가지입니다.(Ingredient, Potion, Product)
- 현재 Ingredient 이미지는 어드레서블에 등록되지 않은 상태라, Ingredient 이미지를 캐싱하는 구문은 주석처리 해놨습니다.
- 외부에서 ImageManager에 접근해 이미지(Sprite)를 가져오고자 할 땐, 아래와 같이 2가지의 호출 방식중 편한 방식을 사용해주세요.
<img width="486" height="58" alt="image" src="https://github.com/user-attachments/assets/fe7ad77f-b080-42c4-80c6-50570525a29c" />

- 핵심은, 가져오고자 하는 이미지의 데이터 타입(ex) PotionData, IngredientData, ProductData)를 메서드 매개변수로든, 제네릭 타입 지정으로든 넣어주셔야 합니다. TID는 당연히 넣어줘야 하구요.




### ⏱️예상 리뷰 시간 : 3m
<br/>

### 📷이슈 번호(선택)
> 생성된 이슈에 대한 PR일 경우, 이슈 번호를 적어주세요. <br/>
<br/>

### 💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.<br/>
