### PR TITLE
Feat | 홀 영역 경로 탐색 알고리즘

### DIFF
--- a/Assets/01. Scenes/Prototype Scenes/LSJ_PrototypeScene.unity
+++ b/Assets/01. Scenes/Prototype Scenes/LSJ_PrototypeScene.unity
@@ -512,7 +512,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   CellSize: 1
   GridSize: {x: 10, y: 10}
-  Origin: {x: 0, y: 0, z: 0}
 --- !u!114 &84351118
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -538,32 +537,26 @@ MonoBehaviour:
     - {x: -4, y: 0, z: -3}
     - {x: -4, y: 0, z: -2}
     - {x: -4, y: 0, z: -1}
-    - {x: -3, y: 0, z: -5}
     - {x: -3, y: 0, z: -4}
     - {x: -3, y: 0, z: -3}
     - {x: -3, y: 0, z: -2}
     - {x: -3, y: 0, z: -1}
-    - {x: -2, y: 0, z: -5}
     - {x: -2, y: 0, z: -4}
     - {x: -2, y: 0, z: -3}
     - {x: -2, y: 0, z: -2}
     - {x: -2, y: 0, z: -1}
-    - {x: -1, y: 0, z: -5}
     - {x: -1, y: 0, z: -4}
     - {x: -1, y: 0, z: -3}
     - {x: -1, y: 0, z: -2}
     - {x: -1, y: 0, z: -1}
-    - {x: 0, y: 0, z: -5}
     - {x: 0, y: 0, z: -4}
     - {x: 0, y: 0, z: -3}
     - {x: 0, y: 0, z: -2}
     - {x: 0, y: 0, z: -1}
-    - {x: 1, y: 0, z: -5}
     - {x: 1, y: 0, z: -4}
     - {x: 1, y: 0, z: -3}
     - {x: 1, y: 0, z: -2}
     - {x: 1, y: 0, z: -1}
-    - {x: 2, y: 0, z: -5}
     - {x: 2, y: 0, z: -4}
     - {x: 2, y: 0, z: -3}
     - {x: 2, y: 0, z: -2}
@@ -632,6 +625,14 @@ MonoBehaviour:
     - {x: 4, y: 0, z: 2}
     - {x: 4, y: 0, z: 3}
     - {x: 4, y: 0, z: 4}
+  - AreaType: 4
+    GridPositionList:
+    - {x: -3, y: 0, z: -5}
+    - {x: -2, y: 0, z: -5}
+    - {x: -1, y: 0, z: -5}
+    - {x: 0, y: 0, z: -5}
+    - {x: 1, y: 0, z: -5}
+    - {x: 2, y: 0, z: -5}
 --- !u!4 &84351119
 Transform:
   m_ObjectHideFlags: 0
@@ -8497,23 +8498,23 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 334938355967586638, guid: eac6f823dbe6ae94e9897e6e6bd9506c, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 334938355967586638, guid: eac6f823dbe6ae94e9897e6e6bd9506c, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 334938355967586638, guid: eac6f823dbe6ae94e9897e6e6bd9506c, type: 3}
       propertyPath: m_SizeDelta.y
-      value: 40
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 334938355967586638, guid: eac6f823dbe6ae94e9897e6e6bd9506c, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 170
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 334938355967586638, guid: eac6f823dbe6ae94e9897e6e6bd9506c, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -20
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 392788075145292359, guid: eac6f823dbe6ae94e9897e6e6bd9506c, type: 3}
       propertyPath: m_AnchorMax.y
@@ -8721,23 +8722,23 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3454726083458952507, guid: eac6f823dbe6ae94e9897e6e6bd9506c, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3454726083458952507, guid: eac6f823dbe6ae94e9897e6e6bd9506c, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3454726083458952507, guid: eac6f823dbe6ae94e9897e6e6bd9506c, type: 3}
       propertyPath: m_SizeDelta.x
-      value: 350
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3454726083458952507, guid: eac6f823dbe6ae94e9897e6e6bd9506c, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 175
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3454726083458952507, guid: eac6f823dbe6ae94e9897e6e6bd9506c, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -40
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3607620090820898304, guid: eac6f823dbe6ae94e9897e6e6bd9506c, type: 3}
       propertyPath: m_AnchorMax.y
@@ -8781,19 +8782,19 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4179636998476618484, guid: eac6f823dbe6ae94e9897e6e6bd9506c, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4179636998476618484, guid: eac6f823dbe6ae94e9897e6e6bd9506c, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4179636998476618484, guid: eac6f823dbe6ae94e9897e6e6bd9506c, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 250
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4179636998476618484, guid: eac6f823dbe6ae94e9897e6e6bd9506c, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -60
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4235553868904883394, guid: eac6f823dbe6ae94e9897e6e6bd9506c, type: 3}
       propertyPath: m_AnchorMax.y
@@ -8817,23 +8818,23 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4492049614787000098, guid: eac6f823dbe6ae94e9897e6e6bd9506c, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4492049614787000098, guid: eac6f823dbe6ae94e9897e6e6bd9506c, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4492049614787000098, guid: eac6f823dbe6ae94e9897e6e6bd9506c, type: 3}
       propertyPath: m_SizeDelta.y
-      value: 40
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4492049614787000098, guid: eac6f823dbe6ae94e9897e6e6bd9506c, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 170
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4492049614787000098, guid: eac6f823dbe6ae94e9897e6e6bd9506c, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -20
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4946795558744916025, guid: eac6f823dbe6ae94e9897e6e6bd9506c, type: 3}
       propertyPath: m_AnchorMax.y
@@ -8917,23 +8918,23 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6386205601636354408, guid: eac6f823dbe6ae94e9897e6e6bd9506c, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6386205601636354408, guid: eac6f823dbe6ae94e9897e6e6bd9506c, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6386205601636354408, guid: eac6f823dbe6ae94e9897e6e6bd9506c, type: 3}
       propertyPath: m_SizeDelta.x
-      value: 350
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6386205601636354408, guid: eac6f823dbe6ae94e9897e6e6bd9506c, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 175
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6386205601636354408, guid: eac6f823dbe6ae94e9897e6e6bd9506c, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -170
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6442641109548161980, guid: eac6f823dbe6ae94e9897e6e6bd9506c, type: 3}
       propertyPath: m_AnchorMax.y
@@ -9109,19 +9110,19 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8262073216026318585, guid: eac6f823dbe6ae94e9897e6e6bd9506c, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8262073216026318585, guid: eac6f823dbe6ae94e9897e6e6bd9506c, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8262073216026318585, guid: eac6f823dbe6ae94e9897e6e6bd9506c, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 250
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8262073216026318585, guid: eac6f823dbe6ae94e9897e6e6bd9506c, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -20
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8565765411350399284, guid: eac6f823dbe6ae94e9897e6e6bd9506c, type: 3}
       propertyPath: m_AnchorMax.y
@@ -9145,23 +9146,23 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8639687365269194135, guid: eac6f823dbe6ae94e9897e6e6bd9506c, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8639687365269194135, guid: eac6f823dbe6ae94e9897e6e6bd9506c, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8639687365269194135, guid: eac6f823dbe6ae94e9897e6e6bd9506c, type: 3}
       propertyPath: m_SizeDelta.y
-      value: 40
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8639687365269194135, guid: eac6f823dbe6ae94e9897e6e6bd9506c, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 70
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8639687365269194135, guid: eac6f823dbe6ae94e9897e6e6bd9506c, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -20
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8883072558719234534, guid: eac6f823dbe6ae94e9897e6e6bd9506c, type: 3}
       propertyPath: m_AnchorMax.y
@@ -9181,23 +9182,23 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8992230905384758264, guid: eac6f823dbe6ae94e9897e6e6bd9506c, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8992230905384758264, guid: eac6f823dbe6ae94e9897e6e6bd9506c, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8992230905384758264, guid: eac6f823dbe6ae94e9897e6e6bd9506c, type: 3}
       propertyPath: m_SizeDelta.y
-      value: 40
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8992230905384758264, guid: eac6f823dbe6ae94e9897e6e6bd9506c, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 70
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8992230905384758264, guid: eac6f823dbe6ae94e9897e6e6bd9506c, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -20
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 9094903673622662836, guid: eac6f823dbe6ae94e9897e6e6bd9506c, type: 3}
       propertyPath: m_AnchorMax.x

--- a/Assets/02. Scripts/02-05. Grid/1. Domain/GridData.cs
+++ b/Assets/02. Scripts/02-05. Grid/1. Domain/GridData.cs
@@ -10,6 +10,7 @@ using UnityEngine;
 public class GridData
 {
     private Dictionary<Vector3Int, Placement> _placedObjectDict = new();
+    public HashSet<Vector3Int> PlacedPositionHashSet => _placedObjectDict.Keys.ToHashSet();
     public ReadOnlyList<int> PlacedObjectList => new ReadOnlyList<int>(_placedObjectDict.Values.Select(placement => placement.TID).ToList());
     private Dictionary<Vector3Int, EAreaType> _availableAreaDict;
 

--- a/Assets/02. Scripts/02-05. Grid/3. Service/GridManager.cs
+++ b/Assets/02. Scripts/02-05. Grid/3. Service/GridManager.cs
@@ -30,6 +30,10 @@ public class GridManager : NetworkBehaviourSingleton<GridManager>
     // 서버 전용: 배치 데이터를 관리합니다.
     private GridData _serverGridData;
 
+    // 길찾기 전용: 그리드 사이즈를 가져오는 용도
+    private GridInfo _gridInfo;
+    private HallAreaPathFinder _hallAreaPathFinder = new();
+
     // 클라이언트 전용: 현재 배치 중인 상태를 관리합니다.
     private IBuildingState _buildingState;
     private Vector3Int _lastDetectedPosition = Vector3Int.zero;
@@ -105,6 +109,8 @@ public class GridManager : NetworkBehaviourSingleton<GridManager>
         _managedStructureDict = new();
         _pickupTableForCustomerList = new();
 
+        _gridInfo = GameObject.FindGameObjectWithTag(nameof(ETags.Layout))?.GetComponent<GridInfo>();
+
         StopPlacement();
         OnInitialized?.Invoke();
     }
@@ -114,6 +120,11 @@ public class GridManager : NetworkBehaviourSingleton<GridManager>
         if (Input.GetKeyDown(KeyCode.F2))
         {
             CmdTest();
+            _hallAreaPathFinder.InitGridPathFinder
+            (GetPositionByAreaType(EAreaType.Hall).ToHashSet(),
+            _serverGridData.PlacedPositionHashSet,
+            GetGridPosition(new Vector3Int(-5, 0, 0)),
+            ToPickupTablePositionHashSet(_pickupTableForCustomerList));
         }
     }
 
@@ -224,27 +235,48 @@ public class GridManager : NetworkBehaviourSingleton<GridManager>
                 _placedObjectInGridSyncDict[pos] = newPlacementData;
             }
 
-            if(data.SpecialStructureType == ESpecialStructureType.PickUpTable)
+            if (data.SpecialStructureType == ESpecialStructureType.PickUpTable)
             {
-                if(_serverGridData.CheckLRUDHasArea(gridPosition, EAreaType.Hall))
+                HandlePickupTablePlacement(structureIdentity, gridPosition, data);
+                _hallAreaPathFinder.UpdateGridPathFinder(_serverGridData.PlacedPositionHashSet,
+                    ToPickupTablePositionHashSet(_pickupTableForCustomerList));
+                if (!_hallAreaPathFinder.HasPath())
                 {
-                    if(_pickupTableForCustomerList.Contains(structureIdentity) == false)
-                    {
-                        _pickupTableForCustomerList.Add(structureIdentity);
-                    }
+                    Debug.LogWarning("경로 없음!!!");
+                    // 경로가 없을 때 로직
                 }
-                else
+            }
+            else if (data.SpecialStructureType == ESpecialStructureType.OldChair
+                || data.SpecialStructureType == ESpecialStructureType.LuxuryChair)
+            {
+                _hallAreaPathFinder.UpdateGridPathFinder(_serverGridData.PlacedPositionHashSet,
+                    ToPickupTablePositionHashSet(_pickupTableForCustomerList));
+                if (!_hallAreaPathFinder.HasPath())
                 {
-                    if (_pickupTableForCustomerList.Contains(structureIdentity))
-                    {
-                        _pickupTableForCustomerList.Remove(structureIdentity);
-                    }
+                    Debug.LogWarning("경로 없음!!!");
+                    // 경로가 없을 때 로직
                 }
             }
 
             TargetRpcOnPlaceStructure(sender, true, structureNetId);
         }
     }
+
+    private void HandlePickupTablePlacement(NetworkIdentity structureIdentity, Vector3Int gridPosition, StructureData data)
+    {
+        if (data.SpecialStructureType == ESpecialStructureType.PickUpTable)
+        {
+            if (_serverGridData.CheckLRUDHasArea(gridPosition, EAreaType.Hall))
+            {
+                _pickupTableForCustomerList.Add(structureIdentity);
+            }
+            else
+            {
+                _pickupTableForCustomerList.Remove(structureIdentity);
+            }
+        }
+    }
+
 
     // --- 클라이언트에게 배치 결과를 전달하는 TargetRpc ---
     [TargetRpc]
@@ -439,6 +471,20 @@ public class GridManager : NetworkBehaviourSingleton<GridManager>
         }
 
         return _serverGridData.PlacedObjectList;
+    }
+
+    private HashSet<Vector3Int> ToPickupTablePositionHashSet(List<NetworkIdentity> pickupTableList)
+    {
+        HashSet<Vector3Int> pickupTablePositionHashSet = new();
+        foreach (NetworkIdentity networkIdentity in pickupTableList)
+        {
+            Vector3Int pickupTableGridPosition = GetGridPosition(networkIdentity.transform.position);
+            if (!pickupTablePositionHashSet.Contains(pickupTableGridPosition))
+            {
+                pickupTablePositionHashSet.Add(pickupTableGridPosition);
+            }
+        }
+        return pickupTablePositionHashSet;
     }
 }
 

--- a/Assets/02. Scripts/02-05. Grid/3. Service/GridManager.cs
+++ b/Assets/02. Scripts/02-05. Grid/3. Service/GridManager.cs
@@ -30,8 +30,6 @@ public class GridManager : NetworkBehaviourSingleton<GridManager>
     // 서버 전용: 배치 데이터를 관리합니다.
     private GridData _serverGridData;
 
-    // 길찾기 전용: 그리드 사이즈를 가져오는 용도
-    private GridInfo _gridInfo;
     private HallAreaPathFinder _hallAreaPathFinder = new();
 
     // 클라이언트 전용: 현재 배치 중인 상태를 관리합니다.
@@ -108,8 +106,6 @@ public class GridManager : NetworkBehaviourSingleton<GridManager>
         _serverGridData = new GridData(_layout.GetAvailableAreaDict());
         _managedStructureDict = new();
         _pickupTableForCustomerList = new();
-
-        _gridInfo = GameObject.FindGameObjectWithTag(nameof(ETags.Layout))?.GetComponent<GridInfo>();
 
         StopPlacement();
         OnInitialized?.Invoke();

--- a/Assets/02. Scripts/02-05. Grid/3. Service/GridManager.cs
+++ b/Assets/02. Scripts/02-05. Grid/3. Service/GridManager.cs
@@ -473,16 +473,8 @@ public class GridManager : NetworkBehaviourSingleton<GridManager>
 
     private HashSet<Vector3Int> ToPickupTablePositionHashSet(List<NetworkIdentity> pickupTableList)
     {
-        HashSet<Vector3Int> pickupTablePositionHashSet = new();
-        foreach (NetworkIdentity networkIdentity in pickupTableList)
-        {
-            Vector3Int pickupTableGridPosition = GetGridPosition(networkIdentity.transform.position);
-            if (!pickupTablePositionHashSet.Contains(pickupTableGridPosition))
-            {
-                pickupTablePositionHashSet.Add(pickupTableGridPosition);
-            }
-        }
-        return pickupTablePositionHashSet;
+        return pickupTableList.Select
+            (networkIdentity => GetGridPosition(networkIdentity.transform.position)).ToHashSet();
     }
 }
 

--- a/Assets/02. Scripts/02-05. Grid/3. Service/GridManager.cs
+++ b/Assets/02. Scripts/02-05. Grid/3. Service/GridManager.cs
@@ -238,16 +238,11 @@ public class GridManager : NetworkBehaviourSingleton<GridManager>
             if (data.SpecialStructureType == ESpecialStructureType.PickUpTable)
             {
                 HandlePickupTablePlacement(structureIdentity, gridPosition, data);
-                _hallAreaPathFinder.UpdateGridPathFinder(_serverGridData.PlacedPositionHashSet,
-                    ToPickupTablePositionHashSet(_pickupTableForCustomerList));
-                if (!_hallAreaPathFinder.HasPath())
-                {
-                    Debug.LogWarning("경로 없음!!!");
-                    // 경로가 없을 때 로직
-                }
             }
-            else if (data.SpecialStructureType == ESpecialStructureType.OldChair
-                || data.SpecialStructureType == ESpecialStructureType.LuxuryChair)
+
+            if (data.SpecialStructureType == ESpecialStructureType.PickUpTable ||
+                data.SpecialStructureType == ESpecialStructureType.OldChair ||
+                data.SpecialStructureType == ESpecialStructureType.LuxuryChair)
             {
                 _hallAreaPathFinder.UpdateGridPathFinder(_serverGridData.PlacedPositionHashSet,
                     ToPickupTablePositionHashSet(_pickupTableForCustomerList));
@@ -268,7 +263,10 @@ public class GridManager : NetworkBehaviourSingleton<GridManager>
         {
             if (_serverGridData.CheckLRUDHasArea(gridPosition, EAreaType.Hall))
             {
-                _pickupTableForCustomerList.Add(structureIdentity);
+                if (!_pickupTableForCustomerList.Contains(structureIdentity))
+                {
+                    _pickupTableForCustomerList.Add(structureIdentity);
+                }
             }
             else
             {

--- a/Assets/02. Scripts/02-05. Grid/3. Service/HallAreaPathFinder.cs
+++ b/Assets/02. Scripts/02-05. Grid/3. Service/HallAreaPathFinder.cs
@@ -67,66 +67,52 @@ public class HallAreaPathFinder
 
     public bool HasPath()
     {
-        // 입구 -> 캐셔
+        // 입구 -> 계산대
         if (!BFS(_entrancePosition, _cashierPosition))
         {
             return false;
         }
 
-        // 캐셔 -> 출구
+        // 계산대 -> 출구
         if (!BFS(_cashierPosition, _exitPosition))
         {
             return false;
         }
 
-        // 캐셔 -> 모든 의자
-        foreach (var chairPos in _chairPositionHashSet)
+        // 계산대 -> 모든 의자
+        if (!BFSToSeveralDestinations(_cashierPosition, _chairPositionHashSet))
         {
-            if (!BFS(_cashierPosition, chairPos))
-            {
-                return false;
-            }
+            return false;
         }
 
-        // 모든 의자 -> 출구
-        foreach (var chairPos in _chairPositionHashSet)
+        // 출구 -> 모든 의자
+        if (!BFSToSeveralDestinations(_exitPosition, _chairPositionHashSet))
         {
-            if (!BFS(chairPos, _exitPosition))
-            {
-                return false;
-            }
+            return false;
+        }
+
+        // 출구 -> 모든 픽업 테이블
+        if (!BFSToSeveralDestinations(_exitPosition, _pickupTablePositionHashSet))
+        {
+            return false;
         }
 
         // 모든 의자 -> 모든 픽업 테이블
-        foreach (var chairPos in _chairPositionHashSet)
+        foreach (var chairPosition in _chairPositionHashSet)
         {
-            foreach (var pickupTablePos in _pickupTablePositionHashSet)
-            {
-                if (!BFS(chairPos, pickupTablePos))
-                {
-                    return false;
-                }
-            }
-        }
-
-        // 모든 픽업 테이블 -> 출구
-        foreach (var pickupTablePos in _pickupTablePositionHashSet)
-        {
-            if (!BFS(pickupTablePos, _exitPosition))
+            if (!BFSToSeveralDestinations(chairPosition, _pickupTablePositionHashSet))
             {
                 return false;
             }
         }
-        Debug.LogWarning("경로 존재");
+
+        Debug.Log("경로 존재");
         return true;
     }
 
     private bool BFS(Vector3Int start, Vector3Int destination)
     {
-        _queue.Clear();
-        _queue.Enqueue(start);
-        _visited.Clear();
-        _visited.Add(start);
+        InitQueueAndVisited(start);
 
         while (_queue.TryDequeue(out Vector3Int currentPosition))
         {
@@ -146,6 +132,44 @@ public class HallAreaPathFinder
             }
         }
         return false;
+    }
+
+    private bool BFSToSeveralDestinations(Vector3Int start, HashSet<Vector3Int> destinationHashSet)
+    {
+        InitQueueAndVisited(start);
+        HashSet<Vector3Int> reachableDestinationHashSet = new();
+        while (_queue.TryDequeue(out Vector3Int currentPosition))
+        {
+            Vector3Int nextPosition;
+            for (int i = 0; i < 4; i++)
+            {
+                nextPosition = currentPosition + _directions[i];
+                if (destinationHashSet.Contains(nextPosition) 
+                    && !reachableDestinationHashSet.Contains(nextPosition))
+                {
+                    reachableDestinationHashSet.Add(nextPosition);
+                }
+                if (IsPositionValid(nextPosition))
+                {
+                    _visited.Add(nextPosition);
+                    _queue.Enqueue(nextPosition);
+                }
+            }
+        }
+
+        if (destinationHashSet.Count == reachableDestinationHashSet.Count)
+        {
+            return true;
+        }
+        return false;
+    }
+
+    private void InitQueueAndVisited(Vector3Int start)
+    {
+        _queue.Clear();
+        _queue.Enqueue(start);
+        _visited.Clear();
+        _visited.Add(start);
     }
 
     private bool IsPositionValid(Vector3Int nextPosition)

--- a/Assets/02. Scripts/02-05. Grid/3. Service/HallAreaPathFinder.cs
+++ b/Assets/02. Scripts/02-05. Grid/3. Service/HallAreaPathFinder.cs
@@ -14,9 +14,13 @@ public class HallAreaPathFinder
     private Vector3Int _entrancePosition = new(-4, 0, -4); // Init 이후 불변
     private Vector3Int _exitPosition = new(4, 0, -4); // Init 이후 불변
 
-
-    private readonly List<int> _dx = new() { 0, 0, -1, 1 };
-    private readonly List<int> _dz = new() { 1, -1, 0, 0 };
+    private readonly Vector3Int[] _directions =
+    {
+        new(0, 0, 1),
+        new(0, 0, -1),
+        new(-1, 0, 0),
+        new(1, 0, 0)
+    };
 
     private Queue<Vector3Int> _queue = new();
     private HashSet<Vector3Int> _visited = new();
@@ -54,8 +58,7 @@ public class HallAreaPathFinder
         _chairPositionHashSet.Clear();
         foreach (var pos in _placedPositionHashSet)
         {
-            if (_hallAreaPositionHashSet.Contains(pos)
-                && !_chairPositionHashSet.Contains(pos))
+            if (_hallAreaPositionHashSet.Contains(pos))
             {
                 _chairPositionHashSet.Add(pos);
             }
@@ -130,7 +133,7 @@ public class HallAreaPathFinder
             Vector3Int nextPosition;
             for (int i = 0; i < 4; i++)
             {
-                nextPosition = currentPosition + new Vector3Int(_dx[i], 0, _dz[i]);
+                nextPosition = currentPosition + _directions[i];
                 if (nextPosition == destination)
                 {
                     return true;

--- a/Assets/02. Scripts/02-05. Grid/3. Service/HallAreaPathFinder.cs
+++ b/Assets/02. Scripts/02-05. Grid/3. Service/HallAreaPathFinder.cs
@@ -172,10 +172,10 @@ public class HallAreaPathFinder
         _visited.Add(start);
     }
 
-    private bool IsPositionValid(Vector3Int nextPosition)
+    private bool IsPositionValid(Vector3Int position)
     {
-        return _hallAreaPositionHashSet.Contains(nextPosition) 
-            && !_placedPositionHashSet.Contains(nextPosition) 
-            && !_visited.Contains(nextPosition);
+        return _hallAreaPositionHashSet.Contains(position) 
+            && !_placedPositionHashSet.Contains(position) 
+            && !_visited.Contains(position);
     }
 }

--- a/Assets/02. Scripts/02-05. Grid/3. Service/HallAreaPathFinder.cs
+++ b/Assets/02. Scripts/02-05. Grid/3. Service/HallAreaPathFinder.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+
+public class HallAreaPathFinder
+{
+    [Header("Depend on Layout")]
+    private HashSet<Vector3Int> _hallAreaPositionHashSet = new(); // Init 이후 불변
+    private HashSet<Vector3Int> _placedPositionHashSet = new(); // 가변
+    private HashSet<Vector3Int> _chairPositionHashSet = new(); // 가변
+    private HashSet<Vector3Int> _pickupTablePositionHashSet = new(); // 가변
+    private Vector3Int _cashierPosition = new(); // Init 이후 불변
+    private Vector3Int _entrancePosition = new(-4, 0, -4); // Init 이후 불변
+    private Vector3Int _exitPosition = new(4, 0, -4); // Init 이후 불변
+
+
+    private readonly List<int> _dx = new() { 0, 0, -1, 1 };
+    private readonly List<int> _dz = new() { 1, -1, 0, 0 };
+
+    private Queue<Vector3Int> _queue = new();
+    private HashSet<Vector3Int> _visited = new();
+
+    public HallAreaPathFinder()
+    {
+    }
+
+    // InitGridManager가 호출되는, 레이아웃이 변경되었을 때 최초 1회 호출
+    public void InitGridPathFinder(
+        HashSet<Vector3Int> gridPositionHashSet,
+        HashSet<Vector3Int> placedPositionHashSet,
+        Vector3Int cashierPosition,
+        HashSet<Vector3Int> pickupTablePositionHashSet)
+    {
+        _hallAreaPositionHashSet = gridPositionHashSet;
+        _placedPositionHashSet = placedPositionHashSet;
+        _cashierPosition = cashierPosition;
+        _pickupTablePositionHashSet = pickupTablePositionHashSet;
+        MakeChairPositionHashSet();
+    }
+
+    // 가구 배치가 바뀔 때마다 호출
+    public void UpdateGridPathFinder
+        (HashSet<Vector3Int> placedPositionHashSet,
+        HashSet<Vector3Int> pickupTablePositionHashSet)
+    {
+        _placedPositionHashSet = placedPositionHashSet;
+        _pickupTablePositionHashSet = pickupTablePositionHashSet;
+        MakeChairPositionHashSet();
+    }
+
+    private void MakeChairPositionHashSet()
+    {
+        _chairPositionHashSet.Clear();
+        foreach (var pos in _placedPositionHashSet)
+        {
+            if (_hallAreaPositionHashSet.Contains(pos)
+                && !_chairPositionHashSet.Contains(pos))
+            {
+                _chairPositionHashSet.Add(pos);
+            }
+        }
+    }
+
+    public bool HasPath()
+    {
+        // 입구 -> 캐셔
+        if (!BFS(_entrancePosition, _cashierPosition))
+        {
+            return false;
+        }
+
+        // 캐셔 -> 출구
+        if (!BFS(_cashierPosition, _exitPosition))
+        {
+            return false;
+        }
+
+        // 캐셔 -> 모든 의자
+        foreach (var chairPos in _chairPositionHashSet)
+        {
+            if (!BFS(_cashierPosition, chairPos))
+            {
+                return false;
+            }
+        }
+
+        // 모든 의자 -> 출구
+        foreach (var chairPos in _chairPositionHashSet)
+        {
+            if (!BFS(chairPos, _exitPosition))
+            {
+                return false;
+            }
+        }
+
+        // 모든 의자 -> 모든 픽업 테이블
+        foreach (var chairPos in _chairPositionHashSet)
+        {
+            foreach (var pickupTablePos in _pickupTablePositionHashSet)
+            {
+                if (!BFS(chairPos, pickupTablePos))
+                {
+                    return false;
+                }
+            }
+        }
+
+        // 모든 픽업 테이블 -> 출구
+        foreach (var pickupTablePos in _pickupTablePositionHashSet)
+        {
+            if (!BFS(pickupTablePos, _exitPosition))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private bool BFS(Vector3Int start, Vector3Int destination)
+    {
+        _queue.Clear();
+        _queue.Enqueue(start);
+        _visited.Clear();
+        _visited.Add(start);
+
+        while (_queue.TryDequeue(out Vector3Int currentPosition))
+        {
+            Vector3Int nextPosition;
+            for (int i = 0; i < 4; i++)
+            {
+                nextPosition = currentPosition + new Vector3Int(_dx[i], 0, _dz[i]);
+                if (nextPosition == destination)
+                {
+                    return true;
+                }
+                if (IsPositionValid(nextPosition))
+                {
+                    _visited.Add(nextPosition);
+                    _queue.Enqueue(nextPosition);
+                }
+            }
+        }
+        return false;
+    }
+
+    private bool IsPositionValid(Vector3Int nextPosition)
+    {
+        return _hallAreaPositionHashSet.Contains(nextPosition) 
+            && !_placedPositionHashSet.Contains(nextPosition) 
+            && !_visited.Contains(nextPosition);
+    }
+}

--- a/Assets/02. Scripts/02-05. Grid/3. Service/HallAreaPathFinder.cs
+++ b/Assets/02. Scripts/02-05. Grid/3. Service/HallAreaPathFinder.cs
@@ -117,7 +117,7 @@ public class HallAreaPathFinder
                 return false;
             }
         }
-
+        Debug.LogWarning("경로 존재");
         return true;
     }
 

--- a/Assets/02. Scripts/02-05. Grid/3. Service/HallAreaPathFinder.cs.meta
+++ b/Assets/02. Scripts/02-05. Grid/3. Service/HallAreaPathFinder.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 61818d4e3cd19694794058dfb6789995

--- a/Assets/02. Scripts/02-05. Grid/LayoutEditing/GridInfo.cs
+++ b/Assets/02. Scripts/02-05. Grid/LayoutEditing/GridInfo.cs
@@ -9,7 +9,7 @@ public class GridInfo : MonoBehaviour
     public Vector2Int GridSize; // 예: (10, 10)
 
     [Tooltip("그리드의 기준점 (일반적으로 Plane의 좌하단 코너)")]
-    public Vector3 Origin;
+    private Vector3 Origin;
 
     // 월드 좌표를 그리드 셀 좌표 (Vector3Int)로 변환
     public Vector3Int WorldToGrid(Vector3 worldPos)


### PR DESCRIPTION
### ※ PR 작성 전 체크리스트 ※
1. 작업하신 브랜치가 최신화되었나요? (behind 커밋이 존재하지 않나요?) ㅔㅔ 
2. 추가하신 기능 및 전체 로직이 정상적으로 동작하는 것을 확인하셨나요? (기능 테스트를 완료하셨나요?) ㅔㅔ
3. Assignee에 본인 계정을 추가하고, labels에 본인 이름 label과 PR의 작업내용을 잘 나타낼 수 있는 라벨을 추가하셨나요? ㅔㅔ
<br/>

### 📝작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.(이미지 첨부 가능)

### 1. HallAreaPathFinder 구현
- 홀 영역에 가구(오래된 의자, 푹신한 의자) 및 픽업 테이블이 배치되었을 때 혹은 위치가 변경 되었을 때, 게임 진행에 핵심이 되는 손님의 이동경로가 존재하는지 검사하는 HallAreaPathFinder를 구현했습니다.
- 검사하는 이동경로는 다음과 같습니다.
1. 포션 상점 입구 -> 계산대 : 1회
2. 계산대 -> 포션 상점 출구  : 1회
3. 계산대 -> 포션 상점에 배치된 모든 의자 : n회
4. 포션 상점에 배치된 모든 의자 -> 포션 상점 출구 : n회
5. 포션 상점에 배치된 모든 의자 -> 포션 상점에 배치된 모든 픽업 테이블 : n^2회
6. 포션 상점에 배치된 모든 픽업 테이블 -> 포션 상점 출구 : n회

- 따라서 원래대로라면 이동경로 검사시, 총 n^3 + 3n + 2회의 BFS 탐색을 진행하게 됩니다.
- 하지만 동일 시작점에 대해 여러번 호출되는 **BFS를 압축하여, 총 BFS 탐색 횟수를 n + 5회로 크게 줄였습니다.** 잘했죠?
- BFS 압축후 탐색 횟수가 n + 5회라 오버헤드는 걱정하실 필요 없습니다.
- 검사 자체는 그리드매니저쪽에서 HasPath만 호출해주시면 됩니다.
     
<br/>

### 2. 그리드 매니저에서 HallAreaPathFinder 사용시 지켜줘야할 사항
- 레이아웃이 변경되었을 땐, **반드시 모든 가구의 소환이 끝난 후에 InitGridPathFinder를 호출해주세요.**
- **의자들 혹은 픽업 테이블이 배치되거나 위치가 바뀌었을 때, 반드시 UpdateGridPathFinder를 호출**해주세요.

<br/>

### 3. LSJ_프로토타입씬 앞마당 영역 그리드 추가

### ⏱️예상 리뷰 시간 : 10m
<br/>

### 📷이슈 번호(선택)
> 생성된 이슈에 대한 PR일 경우, 이슈 번호를 적어주세요. <br/>
<br/>

### 💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.<br/>
