### PR TITLE
Fix | Input Binding할 때 Overlay 수정

### DIFF
--- a/Assets/02. Scripts/02-01. Common/Input/InputMappingManager.cs
+++ b/Assets/02. Scripts/02-01. Common/Input/InputMappingManager.cs
@@ -8,9 +8,6 @@ public class InputMappingManager : MonoBehaviourSingleton<InputMappingManager>
     [SerializeField]
     private InputActionAsset _inputActionAsset;
     public InputActionAsset InputActions => _inputActionAsset;
-    
-    [SerializeField]
-    private GameObject _rebindOverlay;
 
     public event Action<InputAction, EBindingType> OnRebindComplete;
     public event Action OnRebindCanceled;
@@ -30,12 +27,6 @@ public class InputMappingManager : MonoBehaviourSingleton<InputMappingManager>
         {
             Debug.LogError($"Action을 못 찾았습니다.");
             return;
-        }
-        
-
-        if (_rebindOverlay != null)
-        {
-            _rebindOverlay.SetActive(true);
         }
 
         _currentRebindOperation?.Dispose();
@@ -82,11 +73,6 @@ public class InputMappingManager : MonoBehaviourSingleton<InputMappingManager>
         OnRebindComplete?.Invoke(action, bindingType);
         SaveBindingOverrides();
 
-        if (_rebindOverlay != null)
-        {
-            _rebindOverlay.SetActive(false);
-        }
-
         operation.Dispose();
         _currentRebindOperation = null;
     }
@@ -95,11 +81,6 @@ public class InputMappingManager : MonoBehaviourSingleton<InputMappingManager>
     {
         _inputActionAsset.Enable();
         OnRebindCanceled?.Invoke();
-
-        if (_rebindOverlay != null)
-        {
-            _rebindOverlay.SetActive(false);
-        }
 
         operation.Dispose();
         _currentRebindOperation = null;

--- a/Assets/02. Scripts/02-01. Common/Input/UI_RebindAction.cs
+++ b/Assets/02. Scripts/02-01. Common/Input/UI_RebindAction.cs
@@ -22,6 +22,10 @@ public class UI_RebindAction : MonoBehaviour
     [SerializeField]
     private GameObject _activeOverlay;
 
+    [Header("Overlay")]
+    [SerializeField]
+    private GameObject _rebindOverlay;
+
     private void Start()
     {
         InputMappingManager.Instance.OnBindingReset += UpdateBindingDisplay;
@@ -57,6 +61,7 @@ public class UI_RebindAction : MonoBehaviour
     {
         _rebindButton.interactable = false;
         _activeOverlay.SetActive(true);
+        _rebindOverlay.SetActive(true);
 
         InputMappingManager.Instance.OnRebindComplete += HandleRebindComplete;
         InputMappingManager.Instance.OnRebindCanceled += HandleRebindCanceled;
@@ -109,8 +114,6 @@ public class UI_RebindAction : MonoBehaviour
             _bindKeyText.gameObject.SetActive(true);
             _bindImage.gameObject.SetActive(false);
         }
-
-            
     }
 
     private void CleanUp()
@@ -119,6 +122,7 @@ public class UI_RebindAction : MonoBehaviour
         InputMappingManager.Instance.OnRebindCanceled -= HandleRebindCanceled;
 
         _activeOverlay.SetActive(false);
+        _rebindOverlay.SetActive(false);
         _rebindButton.interactable = true;
     }
 }

--- a/Assets/03. Prefabs/Scene UI/LobbyScene/Popup/Popup_Settings.prefab
+++ b/Assets/03. Prefabs/Scene UI/LobbyScene/Popup/Popup_Settings.prefab
@@ -6356,6 +6356,10 @@ PrefabInstance:
       propertyPath: _action
       value: 
       objectReference: {fileID: 6487515695627079516, guid: 052faaac586de48259a63d0c4782560b, type: 3}
+    - target: {fileID: 4574756585557055900, guid: a5dba6be4a971f1418eccaf9916f86bd, type: 3}
+      propertyPath: _rebindOverlay
+      value: 
+      objectReference: {fileID: 4967161948796528640}
     - target: {fileID: 7672789033554956782, guid: a5dba6be4a971f1418eccaf9916f86bd, type: 3}
       propertyPath: m_Name
       value: Button_Setting_MainKey
@@ -7093,6 +7097,10 @@ PrefabInstance:
       propertyPath: _action
       value: 
       objectReference: {fileID: -8272871138912464647, guid: 052faaac586de48259a63d0c4782560b, type: 3}
+    - target: {fileID: 4574756585557055900, guid: a5dba6be4a971f1418eccaf9916f86bd, type: 3}
+      propertyPath: _rebindOverlay
+      value: 
+      objectReference: {fileID: 4967161948796528640}
     - target: {fileID: 7672789033554956782, guid: a5dba6be4a971f1418eccaf9916f86bd, type: 3}
       propertyPath: m_Name
       value: Button_Setting_MainKey
@@ -7213,6 +7221,10 @@ PrefabInstance:
       propertyPath: _action
       value: 
       objectReference: {fileID: 6487515695627079516, guid: 052faaac586de48259a63d0c4782560b, type: 3}
+    - target: {fileID: 4767362030903089198, guid: 871402f9eaea7a242aabee2250c0b53a, type: 3}
+      propertyPath: _rebindOverlay
+      value: 
+      objectReference: {fileID: 4967161948796528640}
     - target: {fileID: 5448920481136270356, guid: 871402f9eaea7a242aabee2250c0b53a, type: 3}
       propertyPath: m_Name
       value: Button_Setting_SubKey
@@ -7413,6 +7425,10 @@ PrefabInstance:
       propertyPath: _action
       value: 
       objectReference: {fileID: 138284816264427201, guid: 052faaac586de48259a63d0c4782560b, type: 3}
+    - target: {fileID: 4767362030903089198, guid: 871402f9eaea7a242aabee2250c0b53a, type: 3}
+      propertyPath: _rebindOverlay
+      value: 
+      objectReference: {fileID: 4967161948796528640}
     - target: {fileID: 5448920481136270356, guid: 871402f9eaea7a242aabee2250c0b53a, type: 3}
       propertyPath: m_Name
       value: Button_Setting_SubKey
@@ -7723,6 +7739,10 @@ PrefabInstance:
       propertyPath: _action
       value: 
       objectReference: {fileID: 1781555164194001046, guid: 052faaac586de48259a63d0c4782560b, type: 3}
+    - target: {fileID: 4767362030903089198, guid: 871402f9eaea7a242aabee2250c0b53a, type: 3}
+      propertyPath: _rebindOverlay
+      value: 
+      objectReference: {fileID: 4967161948796528640}
     - target: {fileID: 5448920481136270356, guid: 871402f9eaea7a242aabee2250c0b53a, type: 3}
       propertyPath: m_Name
       value: Button_Setting_SubKey
@@ -8754,6 +8774,10 @@ PrefabInstance:
       propertyPath: _action
       value: 
       objectReference: {fileID: 138284816264427201, guid: 052faaac586de48259a63d0c4782560b, type: 3}
+    - target: {fileID: 4574756585557055900, guid: a5dba6be4a971f1418eccaf9916f86bd, type: 3}
+      propertyPath: _rebindOverlay
+      value: 
+      objectReference: {fileID: 4967161948796528640}
     - target: {fileID: 7672789033554956782, guid: a5dba6be4a971f1418eccaf9916f86bd, type: 3}
       propertyPath: m_Name
       value: Button_Setting_MainKey
@@ -8954,6 +8978,10 @@ PrefabInstance:
       propertyPath: _action
       value: 
       objectReference: {fileID: 8318684667202039193, guid: 052faaac586de48259a63d0c4782560b, type: 3}
+    - target: {fileID: 4574756585557055900, guid: a5dba6be4a971f1418eccaf9916f86bd, type: 3}
+      propertyPath: _rebindOverlay
+      value: 
+      objectReference: {fileID: 4967161948796528640}
     - target: {fileID: 7672789033554956782, guid: a5dba6be4a971f1418eccaf9916f86bd, type: 3}
       propertyPath: m_Name
       value: Button_Setting_MainKey
@@ -9789,6 +9817,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 4574756585557055900, guid: a5dba6be4a971f1418eccaf9916f86bd, type: 3}
+      propertyPath: _rebindOverlay
+      value: 
+      objectReference: {fileID: 4967161948796528640}
     - target: {fileID: 7672789033554956782, guid: a5dba6be4a971f1418eccaf9916f86bd, type: 3}
       propertyPath: m_Name
       value: Button_Setting_MainKey
@@ -9909,6 +9941,10 @@ PrefabInstance:
       propertyPath: _action
       value: 
       objectReference: {fileID: -8272871138912464647, guid: 052faaac586de48259a63d0c4782560b, type: 3}
+    - target: {fileID: 4767362030903089198, guid: 871402f9eaea7a242aabee2250c0b53a, type: 3}
+      propertyPath: _rebindOverlay
+      value: 
+      objectReference: {fileID: 4967161948796528640}
     - target: {fileID: 5448920481136270356, guid: 871402f9eaea7a242aabee2250c0b53a, type: 3}
       propertyPath: m_Name
       value: Button_Setting_SubKey
@@ -10109,6 +10145,10 @@ PrefabInstance:
       propertyPath: _action
       value: 
       objectReference: {fileID: 8318684667202039193, guid: 052faaac586de48259a63d0c4782560b, type: 3}
+    - target: {fileID: 4767362030903089198, guid: 871402f9eaea7a242aabee2250c0b53a, type: 3}
+      propertyPath: _rebindOverlay
+      value: 
+      objectReference: {fileID: 4967161948796528640}
     - target: {fileID: 5448920481136270356, guid: 871402f9eaea7a242aabee2250c0b53a, type: 3}
       propertyPath: m_Name
       value: Button_Setting_SubKey


### PR DESCRIPTION
### ※ PR 작성 전 체크리스트 ※
1. 작업하신 브랜치가 최신화되었나요? (behind 커밋이 존재하지 않나요?)
2. 추가하신 기능 및 전체 로직이 정상적으로 동작하는 것을 확인하셨나요? (기능 테스트를 완료하셨나요?)
3. Assignee에 본인 계정을 추가하고, labels에 본인 이름 label과 PR의 작업내용을 잘 나타낼 수 있는 라벨을 추가하셨나요?
<br/>

### 📝작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.(이미지 첨부 가능)
<br/>

- InputMappingManager가 Dont Destroy로 바뀌면서 Binding Mode일 때 다른 버튼을 선택 못하게 막는 Overlay를 키고 끄는 부분을 Setting Popup의 Rebinding Button을 통해서 키고 끄는 것으로 바꿨습니다.

### ⏱️예상 리뷰 시간 : 
<br/>

- 1분

### 📷이슈 번호(선택)
> 생성된 이슈에 대한 PR일 경우, 이슈 번호를 적어주세요. <br/>
<br/>

### 💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.<br/>
